### PR TITLE
Add Personality Alignment dataset and PPO script

### DIFF
--- a/examples/run_personality_alignment_ppo.sh
+++ b/examples/run_personality_alignment_ppo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Example script to train PPO on the Personality Alignment dataset.
+
+export HYDRA_FULL_ERROR=1
+
+python3 training/main_async_ppo.py \
+    actor.type._class=qwen3 \
+    actor.path=Qwen/Qwen3-1.7B \
+    ref.type._class=qwen3 \
+    ref.path=Qwen/Qwen3-1.7B \
+    dataset.path=Personality-Alignment/dialogue_dataset.jsonl \
+    dataset.max_prompt_len=1024 \
+    dataset.train_bs_n_seqs=32 \
+    group_size=8 \
+    ppo.gen.max_new_tokens=512 \
+    ppo.ppo_n_minibatches=4
+

--- a/realhf/impl/dataset/personality_alignment_dataset.py
+++ b/realhf/impl/dataset/personality_alignment_dataset.py
@@ -1,0 +1,62 @@
+import json
+from typing import Callable, Dict, List, Optional
+
+import torch
+import torch.utils.data
+
+from realhf.api.core import data_api
+from realhf.base import logging
+
+logger = logging.getLogger("PersonalityAlignmentDataset")
+
+
+class PersonalityAlignmentDataset(torch.utils.data.Dataset):
+    """Dataset for Personality Alignment dialogue prompts."""
+
+    def __init__(
+        self,
+        util: data_api.DatasetUtility,
+        max_length: Optional[int] = None,
+        dataset_path: Optional[str] = None,
+        dataset_builder: Optional[Callable[[], List[Dict]]] = None,
+    ):
+        self._util = util
+        self.max_length = max_length
+
+        data = data_api.load_shuffle_split_dataset(util, dataset_path, dataset_builder)
+        self.ids = [x["qid"] for x in data]
+        prompts = [x["prompt"] for x in data]
+
+        util.tokenizer.padding_side = "left"
+        encodings = util.tokenizer(
+            prompts,
+            truncation=True,
+            max_length=max_length,
+            padding=False,
+            return_length=True,
+            return_attention_mask=False,
+        )
+
+        self.prompts = encodings["input_ids"]
+        self.prompt_lengths = encodings["length"]
+        assert all(len(p) == l for p, l in zip(self.prompts, self.prompt_lengths))
+
+        logger.info(f"Loaded {len(self.prompts)} prompts from Personality Alignment dataset")
+
+    @property
+    def util(self):
+        return self._util
+
+    def __len__(self):
+        return len(self.prompts)
+
+    def __getitem__(self, idx):
+        return data_api.SequenceSample.from_default(
+            ids=[self.ids[idx]],
+            seqlens=[self.prompt_lengths[idx]],
+            data=dict(packed_prompts=torch.tensor(self.prompts[idx], dtype=torch.long)),
+        )
+
+
+data_api.register_dataset("personality-alignment", PersonalityAlignmentDataset)
+


### PR DESCRIPTION
## Summary
- implement `PersonalityAlignmentDataset` for prompts in Personality-Alignment dataset
- add example PPO training script using Qwen3-1.7B

## Testing
- `bash examples/env/scripts/setup-pip-deps.sh` *(fails: Could not install dependencies)*
- `pytest -k personality_alignment_dataset -q` *(fails: ModuleNotFoundError: No module named 'sympy')*

------
https://chatgpt.com/codex/tasks/task_e_6873a102f4b48323a7cb1d4f3f14f638